### PR TITLE
updated install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -30,12 +30,26 @@ http {
 }
 ```
 
-Then copy the new saatchi.nc file to the server:
+Download files from https://uofi.box.com/v/ghgvc-inputs
+
+Then copy the files to the appropriate folders
 
 ```bash
 cd /opt/ghgvc/ghgvc/netcdf
-wget https://s3-us-west-2.amazonaws.com/ghgvc/saatchi.nc
+mkdir -p GCS/Maps
+for f in gez_2010_wgs84.nc Hurtt_SYNMAP_Global_HD_2010.nc hwsd.nc koppen_geiger.nc vegtype.nc;
+ do 
+ mv path/to/$f GCS/Maps/
+done;
+
+for f in path/to/*; 
+  do 
+  mv $f netcdf/
+done;
 ```
+
+(maybe uncomment lines 196, 197, 199 in app/controllers/workflows_controller.rb (?))
+
 
 Finally, you should be able to restart the nginx:
 ```bash
@@ -46,6 +60,4 @@ ps -A | grep nginx
 sudo kill <nginx PID>
 sudo systemctl start nginx
 ```
-
-
 


### PR DESCRIPTION
Update install instructions per comments from David Slater

1.  Had to rename US_forest_biomass_data.nc to US_Forest_biomass_data.nc (capitilize the f).
2.  Create netcdf/GCS/Maps folder
3.  Download gez_2010_wgs84.nc,  Hurtt_SYNMAP_Global_HD_2010.nc, hwsd.nc,  koppen_geiger.nc, and  vegtype.nc into netcdf/GCS/Maps
4.  Download the other maps into netcdf/.  It wasn't only saatchi.nc that I needed.
4.  Only found this out by uncommenting lines 196, 197, 199 in app/controllers/workflows_controller.rb.

@potterzot the primary step I am unsure about is if it is necessary to uncomment lines in app/controllers/workflows_controller.rb from the last step ... if this is the case, should these lines be commented out?